### PR TITLE
Refactor travis scripts, add Windows build and build installers for Linux and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ before_install:
 # non-zero exit status: build status returns failed and exits immediately
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt5; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows"]]; then choco install qtcreator; fi
 
 # OPTIONAL - After dependencies but before the build step
 # non-zero exit status: build status returns failed and exits immediately

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ matrix:
       env:
         - PATH="${PATH}:/usr/local/opt/qt/bin"
         - osx_image="xcode10"
+    - os: windows
 
 # OPTIONAL - which components to cache 
 #cache components:
@@ -67,6 +68,7 @@ before_install:
 # non-zero exit status: build status returns failed and exits immediately
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt5; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows"]]; then choco install qtcreator; fi
 
 # OPTIONAL - After dependencies but before the build step
 # non-zero exit status: build status returns failed and exits immediately
@@ -78,6 +80,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then qmake cinema_scope.pro && make; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$osx_image" == "xcode10" ]]; then qmake -spec macx-xcode cinema_scope.pro && xcodebuild -project cinema_scope.xcodeproj; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$osx_image" != "xcode10" ]]; then qmake cinema_scope.pro && make; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then qmake cinema_scope.pro && make; fi
 
 # OPTIONAL - Cleaning up the cache
 #before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,12 +61,12 @@ matrix:
 # Stuff to do before installing the dependencies          
 # non-zero exit status: build status returns failed and exits immediately
 before_install:
- - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then source /opt/qt511/bin/qt511-env.sh; fi
+ - $TRAVIS_BUILD_DIR/travis/travis_before_install.sh
 
 # Install dependencies here      
 # non-zero exit status: build status returns failed and exits immediately
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt5; fi
+  - $TRAVIS_BUILD_DIR/travis/travis_install.sh
 
 # OPTIONAL - After dependencies but before the build step
 # non-zero exit status: build status returns failed and exits immediately
@@ -75,9 +75,7 @@ install:
 # The build step
 # non-zero exit status: build status returns failed, but continues to run. Intended for the after_failure step
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then qmake cinema_scope.pro && make; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$osx_image" == "xcode10" ]]; then qmake -spec macx-xcode cinema_scope.pro && xcodebuild -project cinema_scope.xcodeproj; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$osx_image" != "xcode10" ]]; then qmake cinema_scope.pro && make; fi
+  - $TRAVIS_BUILD_DIR/travis/travis_script.sh
 
 # OPTIONAL - Cleaning up the cache
 #before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ matrix:
       env:
         - PATH="${PATH}:/usr/local/opt/qt/bin"
         - osx_image="xcode10"
-    - os: windows
 
 # OPTIONAL - which components to cache 
 #cache components:
@@ -79,7 +78,6 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then qmake cinema_scope.pro && make; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$osx_image" == "xcode10" ]]; then qmake -spec macx-xcode cinema_scope.pro && xcodebuild -project cinema_scope.xcodeproj; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$osx_image" != "xcode10" ]]; then qmake cinema_scope.pro && make; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then qmake cinema_scope.pro && make; fi
 
 # OPTIONAL - Cleaning up the cache
 #before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
       env:
         - PATH="${PATH}:/usr/local/opt/qt/bin"
         - osx_image="xcode10"
-    -os: windows
+    - os: windows
 
 # OPTIONAL - which components to cache 
 #cache components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,12 +61,12 @@ matrix:
 # Stuff to do before installing the dependencies          
 # non-zero exit status: build status returns failed and exits immediately
 before_install:
- - $TRAVIS_BUILD_DIR/travis/travis_before_install.sh
+ - . $TRAVIS_BUILD_DIR/travis/travis_before_install.sh
 
 # Install dependencies here      
 # non-zero exit status: build status returns failed and exits immediately
 install:
-  - $TRAVIS_BUILD_DIR/travis/travis_install.sh
+  - . $TRAVIS_BUILD_DIR/travis/travis_install.sh
 
 # OPTIONAL - After dependencies but before the build step
 # non-zero exit status: build status returns failed and exits immediately
@@ -75,7 +75,7 @@ install:
 # The build step
 # non-zero exit status: build status returns failed, but continues to run. Intended for the after_failure step
 script:
-  - $TRAVIS_BUILD_DIR/travis/travis_script.sh
+  - . $TRAVIS_BUILD_DIR/travis/travis_script.sh
 
 # OPTIONAL - Cleaning up the cache
 #before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ matrix:
       env:
         - PATH="${PATH}:/usr/local/opt/qt/bin"
         - osx_image="xcode10"
+    -os: windows
 
 # OPTIONAL - which components to cache 
 #cache components:

--- a/travis/build_installer.sh
+++ b/travis/build_installer.sh
@@ -24,7 +24,6 @@ case $TRAVIS_OS_NAME in
             exit 1
         fi
         ;;
-        ;;
     windows)
         cp -rf build/release/cinema_scope.exe installer/packages/data
         binarycreator -c installer/config/config.xml -p installer/packages cinema_scope_installer.exe

--- a/travis/build_installer.sh
+++ b/travis/build_installer.sh
@@ -14,6 +14,16 @@ case $TRAVIS_OS_NAME in
         fi
         ;;
     osx)
+        cp -rf $TRAVIS_BUILD_DIR/build/release/cinema_scope.app $TRAVIS_BUILD_DIR/installer/packages/data
+        binarycreator -c $TRAVIS_BUILD_DIR/installer/config/config.xml -p $TRAVIS_BUILD_DIR/installer/packages cinema_scope_installer.dmg
+        if [ -e cinema_scope_installer.dmg ]
+        then
+            echo "Installer built!"
+        else
+            echo "Could not find installer file after building it. Failed!"
+            exit 1
+        fi
+        ;;
         ;;
     windows)
         cp -rf build/release/cinema_scope.exe installer/packages/data

--- a/travis/navigate_qt_installer.qs
+++ b/travis/navigate_qt_installer.qs
@@ -1,0 +1,59 @@
+/**
+* This script navigates through the qt installer, selecting the correct
+* tools to download and install.
+*
+* Thanks to https://github.com/sgsaenger/vipster for the example!
+**/
+
+function Controller() {
+    installer.autoRejectMessageBoxes();
+    installer.installationFinished.connect(function() {
+        gui.clickButton(buttons.NextButton);
+    })
+}
+
+Controller.prototype.WelcomePageCallback = function(){
+    gui.clickButton(buttons.NextButton, 3000);
+}
+
+Controller.prototype.CredentialsPageCallback = function(){
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.IntroductionPageCallback = function(){
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.TargetDirectoryPageCallback = function(){
+    gui.currentPageWidget().TargetDirectoryLineEdit.setText(installer.value("HomeDir") + "/Qt");
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ComponentSelectionPageCallback = function(){
+    var widget = gui.currentPageWidget();
+    widget.deselectAll();
+    widget.selectComponent("qt.qt5.5120.win64_mingw73");
+    widget.selectComponent("qt.tools.win64_mingw730");
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.LicenseAgreementPageCallback = function(){
+    gui.currentPageWidget().AcceptLicenseRadioButton.setChecked(true);
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.StartMenuDirectoryPageCallback = function(){
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function(){
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.FinishedPageCallback = function(){
+    var checkBoxForm = gui.currentPageWidget().LaunchQtCreatorCheckBoxForm
+    if (checkBoxForm && checkBoxForm.launchQtCreatorCheckBox){
+        checkBoxForm.launchQtCreatorCheckBox.checked = false;
+    }
+    gui.clickButton(buttons.FinishButton);
+}

--- a/travis/navigate_qt_installer_unix.qs
+++ b/travis/navigate_qt_installer_unix.qs
@@ -1,10 +1,10 @@
 /**
-* This script navigates through the qt installer for Linux, selecting the correct
+* This script navigates through the qt installer for Linux and Mac, selecting the correct
 * tools to download and install.
 *
 * The only difference between this script and the windows one is that this one
 * only downloads the installer framework, because we can get the rest of qt
-* through apt
+* through apt/brew
 *
 * Thanks to https://github.com/sgsaenger/vipster for the example!
 **/

--- a/travis/travis_before_install.sh
+++ b/travis/travis_before_install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+case $TRAVIS_OS_NAME in
+    linux)
+        source /opt/qt511/bin/qt511-env.sh
+        ;;
+    osx)
+        ;;
+    windows)
+        ;;
+esac

--- a/travis/travis_install.sh
+++ b/travis/travis_install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+case $TRAVIS_OS_NAME in
+    linux)
+        ;;
+    osx)
+        then brew install qt5
+        ;;
+    windows)
+        ;;
+esac

--- a/travis/travis_install.sh
+++ b/travis/travis_install.sh
@@ -7,12 +7,18 @@ case $TRAVIS_OS_NAME in
         # (Thanks https://github.com/sgsaenger/vipster for example!)
         travis_wait wget http://download.qt.io/official_releases/online_installers/qt-unified-linux-x64-online.run -q -O qt_installer.run
         chmod +x qt_installer.run
-        travis_wait ./qt_installer.run -platform minimal --script $TRAVIS_BUILD_DIR/travis/navigate_qt_installer_linux.qs
+        travis_wait ./qt_installer.run -platform minimal --script $TRAVIS_BUILD_DIR/travis/navigate_qt_installer_unix.qs
         # Add installer framework to path
-        export PATH="$HOME/Qt/Tools/QtInstallerFramework/3.0/bin:$PATH"
+        ls $HOME/Qt
+        export PATH="$HOME/Qt/QtIFW-3.0/bin:$PATH"
         ;;
     osx)
         brew install qt5
+        travis_wait wget http://download.qt.io/official_releases/online_installers/qt-unified-linux-x64-online.run -q -O qt_installer.run
+        chmod +x qt_installer.run
+        travis_wait ./qt_installer.run -platform minimal --script $TRAVIS_BUILD_DIR/travis/navigate_qt_installer_unix.qs
+        # Add installer framework to path
+        export PATH="$HOME/Qt/Tools/QtInstallerFramework/3.0/bin:$PATH"
         ;;
     windows)
         # Download and run qt installer

--- a/travis/travis_install.sh
+++ b/travis/travis_install.sh
@@ -9,8 +9,8 @@ case $TRAVIS_OS_NAME in
     windows)
         # Download and run qt installer
         # (Thanks https://github.com/sgsaenger/vipster for example!)
-        wget "http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe" -O qt_installer.exe
-        ./qt_installer.exe --verbose --script $TRAVIS_BUILD_DIR/travis/navigate_qt_installer.qs
+        travis_wait wget "http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe" -q -O qt_installer.exe
+        travis_wait ./qt_installer.exe --script $TRAVIS_BUILD_DIR/travis/navigate_qt_installer.qs
         # Add Mingw and qt to path
         export MWDIR="/c/Users/travis/Qt/Tools/mingw730_64"
         export QTDIR="/c/Users/travis/Qt/5.12.0/mingw73_64"

--- a/travis/travis_install.sh
+++ b/travis/travis_install.sh
@@ -10,15 +10,14 @@ case $TRAVIS_OS_NAME in
         travis_wait ./qt_installer.run -platform minimal --script $TRAVIS_BUILD_DIR/travis/navigate_qt_installer_unix.qs
         # Add installer framework to path
         ls $HOME/Qt
-        export PATH="$HOME/Qt/QtIFW-3.0/bin:$PATH"
+        export PATH="$HOME/Qt/Tools/QtInstallerFramework/3.0/bin:$PATH"
         ;;
     osx)
         brew install qt5
-        travis_wait wget http://download.qt.io/official_releases/online_installers/qt-unified-linux-x64-online.run -q -O qt_installer.run
-        chmod +x qt_installer.run
-        travis_wait ./qt_installer.run -platform minimal --script $TRAVIS_BUILD_DIR/travis/navigate_qt_installer_unix.qs
+        travis_wait wget http://download.qt.io/official_releases/online_installers/qt-unified-mac-x64-online.dmg -q -O qt_installer.dmg
+        travis_wait ./qt_installer.dmg -platform minimal --script $TRAVIS_BUILD_DIR/travis/navigate_qt_installer_unix.qs
         # Add installer framework to path
-        export PATH="$HOME/Qt/Tools/QtInstallerFramework/3.0/bin:$PATH"
+        export PATH="$HOME/Qt/QtIFW-3.0/bin:$PATH"
         ;;
     windows)
         # Download and run qt installer

--- a/travis/travis_install.sh
+++ b/travis/travis_install.sh
@@ -4,7 +4,7 @@ case $TRAVIS_OS_NAME in
     linux)
         ;;
     osx)
-        then brew install qt5
+        brew install qt5
         ;;
     windows)
         ;;

--- a/travis/travis_install.sh
+++ b/travis/travis_install.sh
@@ -7,5 +7,13 @@ case $TRAVIS_OS_NAME in
         brew install qt5
         ;;
     windows)
+        # Download and run qt installer
+        # (Thanks https://github.com/sgsaenger/vipster for example!)
+        wget "http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe" -O qt_installer.exe
+        ./qt_installer.exe --verbose --script $TRAVIS_BUILD_DIR/travis/navigate_qt_installer.qs
+        # Add Mingw and qt to path
+        export MWDIR="/c/Users/travis/Qt/Tools/mingw730_64"
+        export QTDIR="/c/Users/travis/Qt/5.12.0/mingw73_64"
+        export PATH="$MWDIR/bin:$QTDIR/bin:$PATH"
         ;;
 esac

--- a/travis/travis_script.sh
+++ b/travis/travis_script.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/bash
+
+case $TRAVIS_OS_NAME in
+    linux)
+        qmake cinema_scope.pro
+        make
+        ;;
+    osx)
+        if [["$osx_image" == "xcode10"]]; then
+            qmake -spec macx-xcode cinema_scope.pro
+            xcodebuild -project cinema_scope.xcodeproj
+        else
+            qmake cinema_scope.pro
+            make
+        fi
+        ;;
+    windows)
+        ;;
+esac

--- a/travis/travis_script.sh
+++ b/travis/travis_script.sh
@@ -16,6 +16,6 @@ case $TRAVIS_OS_NAME in
         ;;
     windows)
         qmake cinema_scope.pro
-        make
+        mingw32-make
         ;;
 esac

--- a/travis/travis_script.sh
+++ b/travis/travis_script.sh
@@ -15,5 +15,7 @@ case $TRAVIS_OS_NAME in
         fi
         ;;
     windows)
+        qmake cinema_scope.pro
+        make
         ;;
 esac


### PR DESCRIPTION
The changes in my pull request refactor the travis scripts for each phase into separate shell scripts which makes them easier to read and change. It also adds a fourth build for Windows systems. Lastly, the CI system builds installers for the Linux and Windows builds.

No Mac installer build yet, but should come soon. Also the installers are built but not yet deployed anywhere.

All four builds are successful on this commit which can be seen here: https://travis-ci.org/camtauxe/cinema_scope/builds/475106971